### PR TITLE
AtCoder Boot Camp Easy 54 - B. Shiritori

### DIFF
--- a/Easy/054/rust/Cargo.toml
+++ b/Easy/054/rust/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rust"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+proconio = "0.5.0"

--- a/Easy/054/rust/src/main.rs
+++ b/Easy/054/rust/src/main.rs
@@ -1,0 +1,67 @@
+// https://atcoder.jp/contests/abc109/tasks/abc109_b
+// B. Shiritori
+// 問題文
+// 高橋くんは今日も 1 人でしりとりの練習をしています。
+// しりとりとは以下のルールで遊ばれるゲームです。
+// ・ はじめ、好きな単語を発言する
+//    以降、次の条件を満たす単語を発言することを繰り返す
+//    ・その単語はまだ発言していない単語である
+//    ・その単語の先頭の文字は直前に発言した単語の末尾の文字と一致する
+// 高橋くんは、10 秒間にできるだけ多くの単語を発言する練習をしています。
+// 高橋くんが発言した単語の個数 N と i 番目に発言した単語 Wi​ が与えられるので、どの発言もしりとりのルールを守っていたかを判定してください。
+// 制約
+//     N は 2≤N≤100 を満たす整数である
+//     Wi​ は英小文字からなる長さ 1 以上 10 以下の文字列である
+use proconio::input;
+use std::collections::HashSet;
+
+fn is_shiritoried(words: &[String]) -> bool {
+    let mut last_char: Option<char> = None;
+    let mut used_words: HashSet<&str> = HashSet::new();
+
+    for word in words.iter() {
+        if !used_words.insert(word.as_str()) {
+            return false;
+        }
+
+        let first = match word.chars().next() {
+            Some(c) => c,
+            None => return false,
+        };
+
+        if let Some(prev) = last_char {
+            if prev != first {
+                return false;
+            }
+        }
+        last_char = word.chars().last();
+    }
+    true
+}
+
+fn main() {
+    input! {
+        n: usize,
+        words: [String; n],
+    }
+
+    println!("{}", if is_shiritoried(&words) { "Yes" } else { "No" });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_shiritoried;
+
+    #[test]
+    fn samples() {
+        assert_eq!(
+            is_shiritoried(&vec![
+                String::from("hoge"),
+                String::from("english"),
+                String::from("hoge"),
+                String::from("enigma")
+            ]),
+            false
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- AtCoder ABC109 B - Shiritori (Rust) を追加
- しりとりの列が有効か判定する: ①単語の重複なし（`HashSet`）②各単語の先頭文字が直前の単語の末尾文字と一致

## Test
- `cargo test` の `tests::samples` がパス（重複ありで `No` を返すケース）
- ロジックは O(N·L)、制約 N≤100 に十分

🤖 Generated with [Claude Code](https://claude.com/claude-code)